### PR TITLE
Update Linux install instructions

### DIFF
--- a/Installation/manual-install-on-linux.md
+++ b/Installation/manual-install-on-linux.md
@@ -6,14 +6,17 @@
 
 Create a directory at / as /blissos
 
-1. Extract initrd.img, ramdisk.img, kernel and system.\* from your desired blissOS ISO into the /blissos directory.
-2. Make a dir called /blissos/data (Only valid for android-pie, for higher versions you need data.img, can be created with make\_ext4fs)
+1. Extract `initrd.img`, `ramdisk.img`, `kernel` and system.\* from your desired blissOS ISO into the /blissos directory. `ramdisk.img` can be ignored for Android 10 and newer as it is already merged into the system (system-as-root).
+2. Make a directory called `/blissos/data`. This will only work for ext4 filesystems, for NTFS and other filesystems or if you are having bootloop you need data.img, can be created with make\_ext4fs. 
 3. Create a new grub entry with this the following code:&#x20;
 
-`menuentry "BlissOS" { set SOURCE_NAME="blissos" search --set=root --file /$SOURCE_NAME/kernel `\
-`      linux /$SOURCE_NAME/kernel quiet root=/dev/ram0 androidboot.hardware=android_x86_64 androidboot.selinux=permissive acpi_sleep=s3_bios,s3_mode SRC=/$SOURCE_NAME  `\
-`     initrd /$SOURCE_NAME/initrd.img`\
-`}`
+```
+menuentry "BlissOS" { 
+    set SOURCE_NAME="blissos" search --set=root --file /$SOURCE_NAME/kernel 
+    linux /$SOURCE_NAME/kernel quiet root=/dev/ram0 SRC=/$SOURCE_NAME  
+    initrd /$SOURCE_NAME/initrd.img
+}
+```
 
 ### **Example for making a 8gb image:**&#x20;
 
@@ -21,3 +24,14 @@ Create a directory at / as /blissos
 dd if=/dev/zero of=data.img bs=1024 count=0 seek=$[102410248]
 sudo mkfs.ext4 -F data.img
 ```
+Alternatively, one can use `truncate`
+```
+truncate -s 8G data.img
+mkfs.ext4 -F -b 4096 -L "/data" data.img
+```
+
+Here are some additional tips for installing BlissOS on Linux:
+- Do not try to install Bliss OS on exotic linux filesystems such ZFS, XFS, BtrFS, currently not every filesystem has built-in support in the Bliss OS kernel, ext4 is supported. If you install it on an unsupported filesystem, it will be stuck at `Detecting Android-x86...`. You will probably have to compile your own kernel and use a modified initrd.img to boot from other filesystems.
+- If you want read-write /system or being able to make changes to the system, simply extract system.img from system.img using a tool that support Zstandard compressed squashFS images. It can also be mounted.
+- For `data.img`, it would be good to repair/check filesystem regularly using command `e2fsck -f data.img`. 
+


### PR DESCRIPTION
- Since a while, users have reported in the BlissOS support channels that they can't boot after following the Linux install instructions. On Bliss OS 14.10/15.8.x builds, the `androidboot.hardware=android_x86_64` parameter is not needed and it won't boot. `androidboot.selinux=permissive` is also not required now.
- Added instructions to create data.img using `truncate` command, some might find it easier.
- I have tested on multiple systems and confirmed that /data as a directory works fine on Android 11/12 also.
- Someone recently installed Bliss OS on XFS filesystem and it failed to boot.  