### PR TITLE
Update FFMPEG and NO_YUV boot flags

### DIFF
--- a/Installation/install-from-windows-uefi-esp-64-bit.md
+++ b/Installation/install-from-windows-uefi-esp-64-bit.md
@@ -74,8 +74,8 @@ HD DRM protected streaming won't work because of the Widevine L3 certification a
 
 "(Default) w/ FFMPEG": Use the default settings with FFMPEG enabled.
 
-  - ```FFMPEG_CODEC=1```: Enable FFMPEG codec support.
-  - ```FFMPEG_PREFER_C2=1```: Use FFMPEG C2 as the preferred codec.
+  - ```FFMPEG_OMX_CODEC=1```: Enable FFMPEG codec support.
+  - ```FFMPEG_CODEC2_PREFER=1```: Use FFMPEG C2 as the preferred codec.
 
 "(Intel) w/ FFMPEG": Use Intel-specific settings with FFMPEG enabled.
 

--- a/configuration/Configuration-through-Command-Line-Parameters.md
+++ b/configuration/Configuration-through-Command-Line-Parameters.md
@@ -127,8 +127,8 @@ In some cases, we are working with hardware that requires Gralloc4 specs. We can
 
 We also offer a few various options that allow you to select different video encoder/decoder stack options:
 
-*   `FFMPEG_CODEC` - This will enable switching to using FFMPEG codecs
-*   `FFMPEG_PREFER_C2` - This will force FFMPEG to use Google C2 codecs
+*   `FFMPEG_OMX_CODEC` - This will enable switching to using FFMPEG codecs
+*   `FFMPEG_CODEC2_PREFER` - This will force FFMPEG to use Google C2 codecs
 *   `FFMPEG_HWACCEL_DISABLE` - This will disable hardware accelleration for the FFMPEG codec
 *   `CODEC2_LEVEL` - This will set the C2 level (typically to disable it '0' along with FFMPEG_HWACCEL_DISABLE)
 *   `NO_YUV420` - This will force the system to not use yuv420 color space (fixes some black or glitchy screens)

--- a/configuration/Configuration-through-Command-Line-Parameters.md
+++ b/configuration/Configuration-through-Command-Line-Parameters.md
@@ -131,7 +131,7 @@ We also offer a few various options that allow you to select different video enc
 *   `FFMPEG_CODEC2_PREFER` - This will force FFMPEG to use Google C2 codecs
 *   `FFMPEG_HWACCEL_DISABLE` - This will disable hardware accelleration for the FFMPEG codec
 *   `CODEC2_LEVEL` - This will set the C2 level (typically to disable it '0' along with FFMPEG_HWACCEL_DISABLE)
-*   `NO_YUV420` - This will force the system to not use yuv420 color space (fixes some black or glitchy screens)
+*   `OMX_NO_YUV420` - This will force the system to not use yuv420 color space (fixes some black or glitchy screens)
 
 ### Audio Stack:
 


### PR DESCRIPTION
They were changed in this commit and in Bliss v15.8.6:
https://github.com/BlissRoms-x86/device_generic_common/commit/93ab3614b21adf9fa3a52bbc03e8eaae5ff2e1ed