### PR TITLE
Update Configuration-through-Command-Line-Parameters.md

### DIFF
--- a/configuration/Configuration-through-Command-Line-Parameters.md
+++ b/configuration/Configuration-through-Command-Line-Parameters.md
@@ -524,7 +524,7 @@ INTEL_PSTATE_STATUS=passive
 
 #### Battery Stats:
 
-*   `androidboot.fake_battery=true`: AOSP implementation of fake battery status
+*   `androidboot.fake_battery=1`: AOSP implementation of fake battery status
 
 (Available through Android-Generic Add-On & add-ons for Bass builds)
 


### PR DESCRIPTION
For faking battery stats, the parameter must be "1" or "0" not "true" or "false"

`androidboot.fake_battery=1` is working as expected.