### PR TITLE
fix: change documentation links from docs to Documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,7 +13,7 @@ contact_links:
     url: https://blissos.org/discord
     about: 'If you need further assistance, join our Discord server.'
   - name: Documentation issue
-    url: https://github.com/BlissRoms-x86/docs
+    url: https://github.com/BlissRoms-x86/Documentation
     about: 'For documentation issues, report it and/or suggest changes on our documentation repository.'
   - name: Knowledgebase issue
     url: https://github.com/BlissRoms-x86/knowledgebase

--- a/development/contributing-documentation.md
+++ b/development/contributing-documentation.md
@@ -4,7 +4,7 @@ We are wide open to users submitting their documentation updates to our docs.bli
 
 **Documentation:**
 
-{% embed url="https://github.com/BlissRoms-x86/docs" %}
+{% embed url="https://github.com/BlissRoms-x86/Documentation" %}
 
 **Knowledgebase:**
 


### PR DESCRIPTION
change links to old, archived documentation to newer doc repo