### PR TITLE
[Advanced Installation] Replaces broken link supposed to lead to main installation guide. (Ref. #26)

### DIFF
--- a/Installation/advanced-installation.md
+++ b/Installation/advanced-installation.md
@@ -1,6 +1,6 @@
 # Advanced Installation
 
-This is only for **advanced users**. For regular users, please visit our main [Installation Guide found here.](installation-guide.md)
+This is only for **advanced users**. For regular users, please visit our other [installation guides found here.](https://docs.blissos.org/#install-bliss-os)
 
 ## Custom Install - Bliss OS 8.x/10.x/11.x UEFI/ESP \(64-bit\)
 


### PR DESCRIPTION
Fixes issue #26 
> Due to @realyukii's initial message containing two issues, this is only issue 1 out of 2. This message will later be edited to reference the second issue too
> 
 
> I can't create new issue so I will comment here, the link mentioned in [this page](https://docs.blissos.org/installation/advanced-installation/) isn't working (404):
> 
> This is only for advanced users. For regular users, please visit our main [Installation Guide found here.](https://docs.blissos.org/installation/advanced-installation/installation-guide.md)
> 
> and the section "Documentation issue" from template issue on [this github repo](https://github.com/BlissRoms-x86/support/issues/new/choose) point to the [archived version](https://github.com/BlissRoms-x86/docs)
> 
> Originally posted by @realyukii in https://github.com/BlissRoms-x86/Documentation/issues/15#issuecomment-2558136790